### PR TITLE
Stream atem to obs with web ui

### DIFF
--- a/atem-relay/README.md
+++ b/atem-relay/README.md
@@ -1,0 +1,34 @@
+# ATEM Relay
+
+Web-configurable relay to ingest RTMP from ATEM Mini Pro ISO and restream to OBS via RTSP/SRT/HLS using MediaMTX. Designed for Debian/Ubuntu LXC on Proxmox.
+
+## Features
+- Web UI to configure stream path and enable/disable protocols and ports
+- Accept RTMP ingest from ATEM
+- Provide RTSP/SRT/HLS pull URLs for OBS or players
+- Status with ffprobe
+- Systemd units and install script
+
+## Quick Install (inside LXC as root)
+```bash
+cd /workspace/atem-relay
+chmod +x install.sh
+./install.sh
+```
+
+Then open `http://<container-ip>:8080`.
+
+## ATEM Setup
+- Streaming service: Custom
+- URL: `rtmp://<container-ip>:1935/<streamPath>` (default `atem`)
+- Key: leave empty
+
+## OBS Setup
+- Add Media Source (for RTSP/HLS) or SRT input
+- RTSP URL: `rtsp://<container-ip>:8554/<streamPath>`
+- HLS URL: `http://<container-ip>:8888/<streamPath>/index.m3u8`
+- SRT URL: `srt://<container-ip>:8890?streamid=publish://<streamPath>`
+
+## Notes
+- All configs stored in `/etc/atem-relay/config.json` and `/etc/mediamtx/mediamtx.yml` but managed via Web UI.
+- Service binaries: `mediamtx` in `/usr/local/bin` and Node app in `/opt/atem-relay`.

--- a/atem-relay/atem-relay.service
+++ b/atem-relay/atem-relay.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=ATEM Relay Web UI and Config Server
+After=network-online.target mediamtx.service
+Wants=network-online.target
+
+[Service]
+Environment=PORT=8080
+Type=simple
+WorkingDirectory=/opt/atem-relay
+ExecStart=/usr/bin/node /opt/atem-relay/server.js
+Restart=on-failure
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target
+

--- a/atem-relay/install.sh
+++ b/atem-relay/install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run as root" >&2
+  exit 1
+fi
+
+apt-get update -y
+apt-get install -y curl ca-certificates ffmpeg
+
+# Install Node.js (LTS) if missing
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+  apt-get install -y nodejs
+fi
+
+# Install MediaMTX
+if ! command -v mediamtx >/dev/null 2>&1; then
+  ARCH=$(uname -m)
+  case "$ARCH" in
+    x86_64) MTX_ARCH=amd64;;
+    aarch64) MTX_ARCH=arm64v8;;
+    armv7l) MTX_ARCH=armv7;;
+    *) echo "Unsupported arch $ARCH"; exit 1;;
+  esac
+  TMP=$(mktemp -d)
+  cd "$TMP"
+  curl -fsSL -o mediamtx.tar.gz https://github.com/bluenviron/mediamtx/releases/latest/download/mediamtx_linux_${MTX_ARCH}.tar.gz
+  tar -xzf mediamtx.tar.gz
+  install -m 0755 mediamtx /usr/local/bin/mediamtx
+  cd /
+  rm -rf "$TMP"
+fi
+
+mkdir -p /etc/mediamtx
+mkdir -p /etc/atem-relay
+
+# Deploy app
+mkdir -p /opt/atem-relay
+cp -r /workspace/atem-relay/* /opt/atem-relay/
+cd /opt/atem-relay
+npm ci --omit=dev || npm install --omit=dev
+
+# Write initial configs
+node -e 'const s=require("./server.js");'
+
+# Systemd services
+cp /opt/atem-relay/mediamtx.service /etc/systemd/system/mediamtx.service
+cp /opt/atem-relay/atem-relay.service /etc/systemd/system/atem-relay.service
+systemctl daemon-reload
+systemctl enable mediamtx.service atem-relay.service
+systemctl restart mediamtx.service atem-relay.service
+
+echo "Install complete. Web UI on http://<container-ip>:8080"
+echo "Point ATEM to rtmp://<container-ip>:1935/atem (default)."
+

--- a/atem-relay/mediamtx.service
+++ b/atem-relay/mediamtx.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=MediaMTX (formerly rtsp-simple-server)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/mediamtx /etc/mediamtx/mediamtx.yml
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+User=root
+Group=root
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target
+

--- a/atem-relay/package.json
+++ b/atem-relay/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "atem-relay",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Web-configurable RTMP ingest from ATEM and retransmit to OBS via RTSP/SRT/HLS using Mediamtx.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/atem-relay/public/app.js
+++ b/atem-relay/public/app.js
@@ -1,0 +1,110 @@
+async function loadConfig() {
+  const res = await fetch('/api/config');
+  return res.json();
+}
+
+async function loadUrls() {
+  const res = await fetch('/api/obs-urls');
+  return res.json();
+}
+
+async function loadStatus() {
+  const res = await fetch('/api/status');
+  return res.json();
+}
+
+function renderUrls(urls) {
+  const el = document.getElementById('urls');
+  el.innerHTML = '';
+  const entries = Object.entries(urls);
+  for (const [k, v] of entries) {
+    const div = document.createElement('div');
+    div.className = 'row';
+    const label = document.createElement('span');
+    label.textContent = k + ':';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.readOnly = true;
+    input.value = v;
+    input.onclick = () => input.select();
+    div.appendChild(label);
+    div.appendChild(input);
+    el.appendChild(div);
+  }
+}
+
+function renderStatus(st) {
+  const el = document.getElementById('status');
+  if (!st.online) {
+    el.textContent = 'Offline (no active stream)';
+    el.className = 'offline';
+  } else {
+    const stream = st.probe?.streams?.[0] || {};
+    const fr = stream.avg_frame_rate || '';
+    el.textContent = `Online: ${stream.codec_name || ''} ${stream.width || ''}x${stream.height || ''} ${fr}`;
+    el.className = 'online';
+  }
+}
+
+async function init() {
+  const cfg = await loadConfig();
+  document.getElementById('streamPath').value = cfg.streamPath;
+  document.getElementById('enable_rtmp').checked = !!cfg.enable.rtmp;
+  document.getElementById('enable_rtsp').checked = !!cfg.enable.rtsp;
+  document.getElementById('enable_srt').checked = !!cfg.enable.srt;
+  document.getElementById('enable_hls').checked = !!cfg.enable.hls;
+  document.getElementById('port_rtmp').value = cfg.listen.rtmp;
+  document.getElementById('port_rtsp').value = cfg.listen.rtsp;
+  document.getElementById('port_srt').value = cfg.listen.srt;
+  document.getElementById('port_hls').value = cfg.listen.hls;
+
+  const urls = await loadUrls();
+  renderUrls(urls);
+  const st = await loadStatus();
+  renderStatus(st);
+
+  document.getElementById('cfgForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const body = {
+      streamPath: document.getElementById('streamPath').value.trim(),
+      enable: {
+        rtmp: document.getElementById('enable_rtmp').checked,
+        rtsp: document.getElementById('enable_rtsp').checked,
+        srt: document.getElementById('enable_srt').checked,
+        hls: document.getElementById('enable_hls').checked,
+      },
+      listen: {
+        rtmp: Number(document.getElementById('port_rtmp').value),
+        rtsp: Number(document.getElementById('port_rtsp').value),
+        srt: Number(document.getElementById('port_srt').value),
+        hls: Number(document.getElementById('port_hls').value),
+      }
+    };
+    const res = await fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) {
+      const t = await res.json().catch(() => ({}));
+      alert('Failed to save: ' + (t.error || res.status));
+      return;
+    }
+    const urls = await loadUrls();
+    renderUrls(urls);
+    setTimeout(async () => {
+      const st = await loadStatus();
+      renderStatus(st);
+    }, 1000);
+  });
+
+  setInterval(async () => {
+    try {
+      const st = await loadStatus();
+      renderStatus(st);
+    } catch (e) {}
+  }, 5000);
+}
+
+init();
+

--- a/atem-relay/public/index.html
+++ b/atem-relay/public/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ATEM Relay</title>
+  <link rel="stylesheet" href="/styles.css" />
+  <link rel="icon" href="data:," />
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
+</head>
+<body>
+  <div class="container">
+    <h1>ATEM Relay</h1>
+    <section>
+      <h2>Configuration</h2>
+      <form id="cfgForm">
+        <label>Stream Path
+          <input type="text" id="streamPath" minlength="1" maxlength="64" pattern="[A-Za-z0-9_\-]+" required />
+        </label>
+        <div class="grid">
+          <label><input type="checkbox" id="enable_rtmp" checked /> RTMP (ingest)</label>
+          <label><input type="checkbox" id="enable_rtsp" checked /> RTSP</label>
+          <label><input type="checkbox" id="enable_srt" checked /> SRT</label>
+          <label><input type="checkbox" id="enable_hls" checked /> HLS</label>
+        </div>
+        <div class="grid">
+          <label>RTMP Port <input type="number" id="port_rtmp" value="1935" /></label>
+          <label>RTSP Port <input type="number" id="port_rtsp" value="8554" /></label>
+          <label>SRT Port <input type="number" id="port_srt" value="8890" /></label>
+          <label>HLS Port <input type="number" id="port_hls" value="8888" /></label>
+        </div>
+        <button type="submit">Save & Apply</button>
+      </form>
+    </section>
+
+    <section>
+      <h2>OBS / Player URLs</h2>
+      <div id="urls"></div>
+    </section>
+
+    <section>
+      <h2>Status</h2>
+      <div id="status">Checking...</div>
+    </section>
+  </div>
+  <script src="/app.js"></script>
+</body>
+</html>
+

--- a/atem-relay/public/styles.css
+++ b/atem-relay/public/styles.css
@@ -1,0 +1,13 @@
+:root { color-scheme: light dark; }
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 0; }
+.container { max-width: 900px; margin: 0 auto; padding: 24px; }
+h1 { margin: 0 0 16px; }
+section { background: rgba(127,127,127,0.08); padding: 16px; border-radius: 8px; margin-bottom: 16px; }
+form label { display: block; margin: 8px 0; }
+input[type="text"], input[type="number"] { width: 100%; padding: 8px; }
+button { padding: 10px 16px; cursor: pointer; }
+.grid { display: grid; grid-template-columns: repeat(2, minmax(200px, 1fr)); gap: 12px; }
+.row { display: grid; grid-template-columns: 180px 1fr; align-items: center; gap: 8px; margin: 6px 0; }
+.online { color: #0a0; }
+.offline { color: #a00; }
+

--- a/atem-relay/server.js
+++ b/atem-relay/server.js
@@ -1,0 +1,172 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync, spawnSync } = require('child_process');
+
+const app = express();
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+const CONFIG_DIR = '/etc/atem-relay';
+const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
+const MEDIAMTX_CONFIG_DIR = '/etc/mediamtx';
+const MEDIAMTX_CONFIG_PATH = path.join(MEDIAMTX_CONFIG_DIR, 'mediamtx.yml');
+
+function ensureDir(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function loadConfig() {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch (e) {
+    const defaults = {
+      streamPath: 'atem',
+      enable: { rtmp: true, rtsp: true, srt: true, hls: true },
+      listen: { rtmp: 1935, rtsp: 8554, hls: 8888, srt: 8890 }
+    };
+    saveConfig(defaults);
+    return defaults;
+  }
+}
+
+function saveConfig(cfg) {
+  ensureDir(CONFIG_DIR);
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2));
+}
+
+function generateMediamtxConfig(cfg) {
+  const enableRTMP = cfg.enable?.rtmp !== false;
+  const enableRTSP = cfg.enable?.rtsp !== false;
+  const enableSRT = cfg.enable?.srt !== false;
+  const enableHLS = cfg.enable?.hls !== false;
+  const lp = cfg.listen || {};
+  const lines = [];
+  lines.push('logLevel: warn');
+  if (enableRTMP) lines.push(`rtmp: yes`); else lines.push('rtmp: no');
+  if (enableRTSP) lines.push(`rtsp: yes`); else lines.push('rtsp: no');
+  if (enableSRT) lines.push(`srt: yes`); else lines.push('srt: no');
+  if (enableHLS) lines.push(`hls: yes`); else lines.push('hls: no');
+  if (enableRTMP) lines.push(`rtmpAddress: :${lp.rtmp || 1935}`);
+  if (enableRTSP) lines.push(`rtspAddress: :${lp.rtsp || 8554}`);
+  if (enableHLS) lines.push(`hlsAddress: :${lp.hls || 8888}`);
+  if (enableSRT) lines.push(`srtAddress: :${lp.srt || 8890}`);
+  lines.push('');
+  lines.push('paths:');
+  lines.push(`  ${cfg.streamPath}:`);
+  lines.push('    # RTMP/RTSP/SRT publishers (ATEM) will publish to this path');
+  lines.push('    # OBS or other players pull from the same path');
+  lines.push('    source: publisher');
+  return lines.join('\n') + '\n';
+}
+
+function writeMediamtxConfig(cfg) {
+  ensureDir(MEDIAMTX_CONFIG_DIR);
+  const content = generateMediamtxConfig(cfg);
+  fs.writeFileSync(MEDIAMTX_CONFIG_PATH, content);
+}
+
+function restartMediamtx() {
+  try {
+    execSync('systemctl reload mediamtx.service', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    try {
+      execSync('systemctl restart mediamtx.service', { stdio: 'ignore' });
+      return true;
+    } catch (e2) {
+      return false;
+    }
+  }
+}
+
+function getLocalIPs() {
+  const nets = os.networkInterfaces();
+  const addrs = [];
+  for (const name of Object.keys(nets)) {
+    for (const net of nets[name] || []) {
+      if (net.family === 'IPv4' && !net.internal) addrs.push(net.address);
+    }
+  }
+  return addrs.length ? addrs : ['127.0.0.1'];
+}
+
+app.get('/api/config', (req, res) => {
+  res.json(loadConfig());
+});
+
+app.post('/api/config', (req, res) => {
+  const body = req.body || {};
+  const streamPath = String(body.streamPath || '').trim();
+  if (!/^[a-zA-Z0-9_\-]{1,64}$/.test(streamPath)) {
+    return res.status(400).json({ error: 'Invalid streamPath. Use letters, numbers, _ or -' });
+  }
+  const enable = {
+    rtmp: !!(body.enable?.rtmp ?? true),
+    rtsp: !!(body.enable?.rtsp ?? true),
+    srt: !!(body.enable?.srt ?? true),
+    hls: !!(body.enable?.hls ?? true)
+  };
+  const listen = {
+    rtmp: Number(body.listen?.rtmp ?? 1935),
+    rtsp: Number(body.listen?.rtsp ?? 8554),
+    hls: Number(body.listen?.hls ?? 8888),
+    srt: Number(body.listen?.srt ?? 8890)
+  };
+  const cfg = { streamPath, enable, listen };
+  saveConfig(cfg);
+  writeMediamtxConfig(cfg);
+  restartMediamtx();
+  res.json({ ok: true, cfg });
+});
+
+app.get('/api/obs-urls', (req, res) => {
+  const cfg = loadConfig();
+  const host = getLocalIPs()[0];
+  const stream = cfg.streamPath;
+  const ports = cfg.listen;
+  res.json({
+    rtmp_publish: `rtmp://${host}:${ports.rtmp}/${stream}`,
+    rtsp_pull: `rtsp://${host}:${ports.rtsp}/${stream}`,
+    srt_pull: `srt://${host}:${ports.srt}?streamid=publish://${stream}`,
+    hls_pull: `http://${host}:${ports.hls}/${stream}/index.m3u8`
+  });
+});
+
+app.get('/api/status', (req, res) => {
+  const cfg = loadConfig();
+  const url = `rtsp://127.0.0.1:${cfg.listen.rtsp}/${cfg.streamPath}`;
+  try {
+    const out = spawnSync('ffprobe', [
+      '-v', 'error',
+      '-select_streams', 'v:0',
+      '-show_entries', 'stream=codec_name,width,height,avg_frame_rate',
+      '-of', 'json',
+      url
+    ], { encoding: 'utf8', timeout: 3000 });
+    if (out.status !== 0) throw new Error(out.stderr || 'ffprobe failed');
+    const data = JSON.parse(out.stdout || '{}');
+    res.json({ online: true, probe: data });
+  } catch (e) {
+    res.json({ online: false });
+  }
+});
+
+// Fallback to SPA index
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+const PORT = process.env.PORT || 8080;
+ensureDir(CONFIG_DIR);
+const current = loadConfig();
+writeMediamtxConfig(current);
+app.listen(PORT, () => {
+  /* eslint-disable no-console */
+  console.log(`atem-relay server listening on :${PORT}`);
+});
+


### PR DESCRIPTION
Add `atem-relay` service with a web UI to configure RTMP ingest from ATEM and retransmit video to OBS via RTSP/SRT/HLS.

---
<a href="https://cursor.com/background-agent?bcId=bc-351df799-3b02-4662-b7bd-9cbbf18ef970">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-351df799-3b02-4662-b7bd-9cbbf18ef970">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

